### PR TITLE
Position increment controller

### DIFF
--- a/bimanual_handover/bimanual_direct_env_cfg.py
+++ b/bimanual_handover/bimanual_direct_env_cfg.py
@@ -59,7 +59,7 @@ def rot2tensor(rot: Rotation) -> torch.tensor:
 @configclass
 class BimanualDirectCfg(DirectRLEnvCfg):
     # env
-    decimation = 2              # Number of control action updates @ sim dt per policy dt.
+    decimation = 3              # Number of control action updates @ sim dt per policy dt.
     episode_length_s = 3.0      # Length of the episode in seconds
     steps_reset = 40            # Maximum steps in an episode
     angle_scale = pi            # Action angle scalation
@@ -243,12 +243,15 @@ class BimanualDirectCfg(DirectRLEnvCfg):
     ee_init_pose = torch.cat((ee_init_pose_quat[:,:3], euler), dim = -1)
 
     # Increments in the original poses for sampling random values on each axis
-    ee_pose_incs = torch.tensor([[-0.1,  0.1],
-                                 [-0.1,  0.1],
-                                 [-0.1,  0.1],
+    ee_pose_incs = torch.tensor([[-0.3,  0.3],
                                  [-0.3,  0.3],
                                  [-0.3,  0.3],
-                                 [-0.3,  0.3]])
+                                 [-0.6,  0.6],
+                                 [-0.6,  0.6],
+                                 [-0.6,  0.6]])
+    
+    # To which robot apply the sampling poses
+    apply_range = [True, False]
     
     # Translation respect to the object link frame for object grasping point observation
     grasp_obs_obj_pos_trans = torch.tensor([0.0, 0.0, 0.1])

--- a/bimanual_handover/bimanual_direct_env_cfg.py
+++ b/bimanual_handover/bimanual_direct_env_cfg.py
@@ -60,9 +60,10 @@ def rot2tensor(rot: Rotation) -> torch.tensor:
 class BimanualDirectCfg(DirectRLEnvCfg):
     # env
     decimation = 2              # Number of control action updates @ sim dt per policy dt.
-    episode_length_s = 1.0      # Length of the episode in seconds
+    episode_length_s = 3.0      # Length of the episode in seconds
     steps_reset = 40            # Maximum steps in an episode
-    angle_scale = pi            # Angle scalation
+    angle_scale = pi            # Action angle scalation
+    translation_scale = torch.tensor([0.01, 0.01, 0.01]) # Action translation scalation
 
     num_actions = 7 + 16        # Number of actions per environment (overridden)
     num_observations = 12 + 14  # Number of observations per environment (overridden)
@@ -242,12 +243,12 @@ class BimanualDirectCfg(DirectRLEnvCfg):
     ee_init_pose = torch.cat((ee_init_pose_quat[:,:3], euler), dim = -1)
 
     # Increments in the original poses for sampling random values on each axis
-    ee_pose_incs = torch.tensor([[-0.2,  0.2],
-                                 [-0.2,  0.2],
-                                 [-0.2,  0.2],
-                                 [-0.8,  0.8],
-                                 [-0.8,  0.8],
-                                 [-0.8,  0.8]])
+    ee_pose_incs = torch.tensor([[-0.1,  0.1],
+                                 [-0.1,  0.1],
+                                 [-0.1,  0.1],
+                                 [-0.3,  0.3],
+                                 [-0.3,  0.3],
+                                 [-0.3,  0.3]])
     
     # Translation respect to the object link frame for object grasping point observation
     grasp_obs_obj_pos_trans = torch.tensor([0.0, 0.0, 0.1])
@@ -276,6 +277,9 @@ def update_cfg(cfg, num_envs, device):
     Out:
         - cfg - BimanualDirectCfg: modified configuration class
     '''
+
+    cfg.translation_scale = cfg.translation_scale.to(device)
+
     cfg.obj_pos_trans = cfg.obj_pos_trans.repeat(num_envs, 1).to(device)
     cfg.obj_quat_trans = cfg.obj_quat_trans.repeat(num_envs, 1).to(device)
 


### PR DESCRIPTION
Position increment controller. At the moment, the increments are only applied to the GEN3 robot.
The robots move according to the end effector frame, not the base.

A flag has been added to indicate which robot has sampling ranges when obtaining spawning poses at reset.
